### PR TITLE
Remove activemq-tls docker service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,7 @@ install-tools:
 	@go mod tidy
 
 up:
-	docker compose -f test/docker-compose.yml up activemq --quiet-pull -d --wait
-
-up-dev:
-	docker compose -f test/docker-compose.yml up activemq-dev --quiet-pull -d --wait 
+	docker compose -f test/docker-compose.yml up --quiet-pull -d --wait
 
 down:
 	docker compose -f test/docker-compose.yml down -v --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-tools:
 	@go mod tidy
 
 up:
-	docker compose -f test/docker-compose.yml up activemq activemq-tls --quiet-pull -d --wait 
+	docker compose -f test/docker-compose.yml up activemq --quiet-pull -d --wait
 
 up-dev:
 	docker compose -f test/docker-compose.yml up activemq-dev --quiet-pull -d --wait 

--- a/test/activemq.xml
+++ b/test/activemq.xml
@@ -103,6 +103,7 @@
             http://activemq.apache.org/configuring-transports.html
         -->
         <transportConnectors>
+            <transportConnector name="tcp" uri="stomp://0.0.0.0:61613"/>
             <transportConnector name="ssl" uri="stomp+ssl://0.0.0.0:61617"/>
         </transportConnectors>
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,8 +2,9 @@ version: '3.8'
 
 services:
   activemq:
-    image: apache/activemq-classic
+    image: apache/activemq-classic:6.0.1
     container_name: activemq-classic
+    init: true
     ports:
       - "61613:61613"
       - "61617:61617"
@@ -22,21 +23,3 @@ services:
       timeout: 20s
       retries: 6
       start_period: 30s
-
-  # for development: starts fast, stops faster
-  activemq-dev:
-    stop_grace_period: 100ms
-    image: apache/activemq-classic
-    container_name: activemq-classic-dev
-    ports:
-      - "61613:61613"
-    environment:
-      ACTIVEMQ_CONNECTION_USER: "admin"
-      ACTIVEMQ_CONNECTION_PASSWORD: "admin"
-    healthcheck:
-      test: ["CMD", "curl", "http://localhost:8161"]
-      interval: 100ms
-      timeout: 20s
-      retries: 100
-      start_period: 100ms
-

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -6,20 +6,6 @@ services:
     container_name: activemq-classic
     ports:
       - "61613:61613"
-    environment:
-      ACTIVEMQ_CONNECTION_USER: "admin"
-      ACTIVEMQ_CONNECTION_PASSWORD: "admin"
-    healthcheck:
-      test: ["CMD", "curl", "http://localhost:8161"]
-      interval: 5s
-      timeout: 20s
-      retries: 6
-      start_period: 30s
-
-  activemq-tls:
-    image: apache/activemq-classic
-    container_name: activemq-classic-tls
-    ports:
       - "61617:61617"
     environment:
       ACTIVEMQ_CONNECTION_USER: "admin"
@@ -36,7 +22,6 @@ services:
       timeout: 20s
       retries: 6
       start_period: 30s
-
 
   # for development: starts fast, stops faster
   activemq-dev:


### PR DESCRIPTION
### Description

In spirit of https://github.com/alarbada/conduit-connector-activemq-artemis/pull/8#pullrequestreview-1986863731, here the `activemq-tls` docker service is removed.
